### PR TITLE
[RGF] enhance_product_and_order_services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov
 .DS_Store
 **/*.log
 stats.xml
+.idea

--- a/dev_pytest.sh
+++ b/dev_pytest.sh
@@ -1,3 +1,3 @@
-coverage run -m pytest gateway/test 
+coverage run -m pytest gateway/test
 coverage run --append -m pytest orders/test
 coverage run --append -m pytest products/test

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -196,7 +196,7 @@ class GatewayService(object):
 
     def _create_order(self, order_data):
         # check order product ids are valid
-        valid_product_ids = {prod['id'] for prod in self.products_rpc.list()}
+        valid_product_ids = {self._format_id(prod['title']) for prod in self.products_rpc.list_ids()}
         for item in order_data['order_details']:
             if item['product_id'] not in valid_product_ids:
                 raise ProductNotFound(
@@ -211,3 +211,6 @@ class GatewayService(object):
             serialized_data['order_details']
         )
         return result['id']
+
+    def _format_id(self, product_id):
+        return product_id.lower().replace('products:', '')

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -22,6 +22,19 @@ class GatewayService(object):
     products_rpc = RpcProxy('products')
 
     @http(
+        "GET", "/products",
+        expected_exceptions=BadRequest
+    )
+    def list_products(self, request):
+        """Gets product list
+        """
+        products = self.products_rpc.list()
+        return Response(
+            ProductSchema(many=True).dumps(products).data,
+            mimetype='application/json'
+        )
+
+    @http(
         "GET", "/products/<string:product_id>",
         expected_exceptions=ProductNotFound
     )
@@ -72,6 +85,32 @@ class GatewayService(object):
         self.products_rpc.create(product_data)
         return Response(
             json.dumps({'id': product_data['id']}), mimetype='application/json'
+        )
+
+    @http(
+        "DELETE", "/products/<string:product_id>",
+        expected_exceptions=ProductNotFound
+    )
+    def delete_product(self, request, product_id):
+        """Delete product by `product_id`
+        """
+        response = self.products_rpc.delete(product_id)
+        return Response(
+            ProductSchema().dumps(response).data,
+            mimetype='application/json'
+        )
+
+    @http(
+        "GET", "/orders",
+        expected_exceptions=BadRequest
+    )
+    def list_orders(self, request):
+        """Gets Order List
+        """
+        orders = self.orders_rpc.list_orders()
+        return Response(
+            GetOrderSchema(many=True).dumps(orders).data,
+            mimetype='application/json'
         )
 
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -81,6 +81,27 @@ class TestCreateProduct(object):
         assert response.json()['error'] == 'VALIDATION_ERROR'
 
 
+class TestDeleteProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.return_value = {
+            "id": "the_odyssey"
+        }
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 200
+        assert response.json() == {"id": "the_odyssey"}
+
+    def test_product_not_found(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.side_effect = (
+            ProductNotFound('missing'))
+
+        # call the gateway service to get order #1
+        response = web_session.delete('/products/foo')
+        assert response.status_code == 404
+        payload = response.json()
+        assert payload['error'] == 'PRODUCT_NOT_FOUND'
+        assert payload['message'] == 'missing'
+
+
 class TestGetOrder(object):
 
     def test_can_get_order(self, gateway_service, web_session):

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -66,3 +66,8 @@ class OrdersService:
         order = self.db.query(Order).get(order_id)
         self.db.delete(order)
         self.db.commit()
+
+    @rpc
+    def list_orders(self):
+        orders = self.db.query(Order).all()
+        return OrderSchema(many=True).dump(orders).data

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -34,6 +34,17 @@ def test_get_order(orders_rpc, order):
     assert response['id'] == order.id
 
 
+def test_list_orders(orders_rpc, order):
+    response = orders_rpc.list_orders()
+    assert isinstance(response, list)
+    assert len(response) == 1
+
+
+def test_list_orders_when_empty(orders_rpc):
+    response = orders_rpc.list_orders()
+    assert isinstance(response, list)
+
+
 @pytest.mark.usefixtures('db_session')
 def test_will_raise_when_order_not_found(orders_rpc):
     with pytest.raises(RemoteError) as err:

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -49,6 +49,10 @@ class StorageWrapper:
         for key in keys:
             yield self._from_hash(self.client.hgetall(key))
 
+    def list_ids(self):
+        keys = self.client.keys(self._format_key('*'))
+        return keys
+
     def create(self, product):
         self.client.hmset(
             self._format_key(product['id']),

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -37,11 +37,12 @@ class StorageWrapper:
         }
 
     def get(self, product_id):
+        # validate if the product_id exists
+        self.__validate_if_product_exists(product_id)
+
+        # get the product
         product = self.client.hgetall(self._format_key(product_id))
-        if not product:
-            raise NotFound('Product ID {} does not exist'.format(product_id))
-        else:
-            return self._from_hash(product)
+        return self._from_hash(product)
 
     def list(self):
         keys = self.client.keys(self._format_key('*'))
@@ -53,9 +54,23 @@ class StorageWrapper:
             self._format_key(product['id']),
             product)
 
+    def delete(self, product_id):
+        # validate if the product_id exists
+        self.__validate_if_product_exists(product_id)
+
+        # delete the product
+        keys = list(self.client.hgetall(self._format_key(product_id)).keys())
+        self.client.hdel(self._format_key(product_id), *keys)
+        return {"id": product_id}
+
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(
             self._format_key(product_id), 'in_stock', -amount)
+
+    def __validate_if_product_exists(self, product_id):
+        product = self.client.hkeys(self._format_key(product_id))
+        if not product:
+            raise NotFound('Product ID {} does not exist'.format(product_id))
 
 
 class Storage(DependencyProvider):

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -30,6 +30,11 @@ class ProductsService:
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)
 
+    @rpc
+    def delete(self, product_id):
+        product = self.storage.delete(product_id)
+        return schemas.Product().dump(product).data
+
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
         for product in payload['order']['order_details']:

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -26,6 +26,11 @@ class ProductsService:
         return schemas.Product(many=True).dump(products).data
 
     @rpc
+    def list_ids(self):
+        products = self.storage.list_ids()
+        return schemas.Product(many=True).dump(products).data
+
+    @rpc
     def create(self, product):
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -28,6 +28,18 @@ def test_get(storage, products):
     assert 11 == product['in_stock']
 
 
+def test_delete(storage, products):
+    product_id_to_delete = 'LZ129'
+    product = storage.delete(product_id_to_delete)
+    assert product_id_to_delete == product['id']
+
+
+def test_delete_fails_on_not_found(storage):
+    with pytest.raises(storage.NotFound) as exc:
+        storage.delete(2)
+    assert 'Product ID 2 does not exist' == exc.value.args[0]
+
+
 def test_list(storage, products):
     listed_products = storage.list()
     assert (

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -32,6 +32,21 @@ def test_get_product_fails_on_not_found(service_container):
             get(111)
 
 
+def test_delete_product(create_product, service_container):
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        loaded_product = delete(stored_product['id'])
+
+    assert stored_product['id'] == loaded_product['id']
+
+
+def test_delete_product_fails_on_not_found(service_container):
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'delete') as delete:
+            delete(111)
+
+
 def test_list_products(products, service_container):
 
     with entrypoint_hook(service_container, 'list') as list_:
@@ -40,7 +55,7 @@ def test_list_products(products, service_container):
     assert products == sorted(listed_products, key=lambda p: p['id'])
 
 
-def test_list_productis_when_empty(service_container):
+def test_list_products_when_empty(service_container):
 
     with entrypoint_hook(service_container, 'list') as list_:
         listed_products = list_()

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -64,7 +64,12 @@ scenarios:
         product_key: $.id
         default: NOT_FOUND
 
-    # 3. Create Orders
+    - if: '"${product_key}" == "NOT_FOUND"'
+      then:
+        - action: continue
+
+
+      # 3. Create Orders
     - url: /orders
       label: orders-create
       think-time: uniform(0s, 0s)
@@ -108,7 +113,27 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
-  
+
+    # 5. List Orders
+    - url: /orders
+      label: orders-list
+      think-time: uniform(0s, 0s)
+      method: GET
+
+      assert:
+        - contains:
+            - 200
+          subject: http-code
+          not: false
+      extract-jsonpath:
+        orders: $
+        default: NOT_FOUND
+
+    - if: '"${orders}" == "NOT_FOUND"'
+      then:
+        - action: continue
+
+
 reporting:
 - module: final-stats
   dump-xml: stats.xml

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -52,3 +52,17 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: Get lists of Products
+echo "=== Getting Product list ==="
+curl -s "${STD_APP_URL}/products" | jq .
+
+# Test: Get lists of Orders
+echo "=== Getting Orders list ==="
+curl -s "${STD_APP_URL}/orders" | jq .
+
+# Test: DELETE Product
+echo "=== Deleting product id: the_odyssey ==="
+curl -X DELETE "${STD_APP_URL}/products/the_odyssey" \
+     -H 'accept: application/json'
+echo


### PR DESCRIPTION
**Enhance product service**

-    Delete product rpc call
-    Wire into smoketest.sh
-    Wire into perf-test
-    Wire unit-test for this method

**Enhance order service**

-    List orders rpc call
-    Wire into smoketest.sh
-    Wire into perf-test
-    Wire unit-test for this method

**Execute performance test**

- **Question 1:** Why is performance degrading as the test run longer ?
- **Answer 1:** Because when we are getting the list of products, for every key we are connecting to database and getting all fields this causes the degrading. 
- **Question 2:** How do you fix it ?
- **Answer 2:** for the validation about existing products just we need the ids, we don't need to access to all fields so just I'm accessing to the product ids. Other better solution can be caching this data but this only works if products don't change all the time.
- Fix it

**Test of everything is running correctly:**
**Services Running:**
![nameco-devex Service Running](https://user-images.githubusercontent.com/12434820/188918639-79d15a4f-fe05-4e15-837f-306b058cc1c3.png)

**Logs of Unit Test:**
![Unit Test 1](https://user-images.githubusercontent.com/12434820/188918400-a31deb2c-4456-45aa-b98a-807b2d45b24c.png)
![Unit Test 2](https://user-images.githubusercontent.com/12434820/188918493-7040cac7-7087-4189-9277-0a9dc307fddf.png)
![Unit Test 3](https://user-images.githubusercontent.com/12434820/188918516-5651b37d-8cf8-49e5-adb9-32e968ba0a88.png)

**Logs of Smoketests:**
![Smoketest 1](https://user-images.githubusercontent.com/12434820/188918833-5e84e9a5-10bb-4613-baf7-41728e3f47b7.png)
![Smoketest 2](https://user-images.githubusercontent.com/12434820/188918850-82fba79f-78c5-48c6-825e-0800d3e9b4a3.png)

**Logs of bzt performance tests:**
![bzt logs 1](https://user-images.githubusercontent.com/12434820/188918994-2b2d9c83-2ebb-4ec2-a7b0-d191e19b54d6.png)
![bzt logs 2](https://user-images.githubusercontent.com/12434820/188919015-30147c69-9f4c-49d7-9790-4aa900cb87f2.png)

**Reports on BlazeMeter:**
**Summary**
![BlazeMeter-Summary](https://user-images.githubusercontent.com/12434820/188919132-6d870ff9-710c-4671-8c63-e36fc19136e1.png)

**Timeline Report with orders-create:**
![Screen Shot 2022-09-07 at 17 47 58](https://user-images.githubusercontent.com/12434820/188990119-2e5827cb-7341-4a3c-8314-414417c2d072.png)

**Requests Stats:**
![Screen Shot 2022-09-07 at 17 48 36](https://user-images.githubusercontent.com/12434820/188990166-f61d13d4-feb7-4bd5-b9e5-e09500fa5548.png)

**Engine Health:**
![Screen Shot 2022-09-07 at 17 48 59](https://user-images.githubusercontent.com/12434820/188990201-62468d75-c3f0-4d6b-bfb2-64df33858b18.png)

**Errors:**
![Screen Shot 2022-09-07 at 17 49 12](https://user-images.githubusercontent.com/12434820/188990213-b7caf750-5380-4e1a-bc5c-a92501fdb977.png)




